### PR TITLE
Add annotation to ServiceGlobalModeOptions

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/ServiceGlobalModeOptions.java
+++ b/src/main/java/com/github/dockerjava/api/model/ServiceGlobalModeOptions.java
@@ -11,6 +11,7 @@ import java.io.Serializable;
 /**
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ServiceGlobalModeOptions implements Serializable {
     public static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
This fixes the "No serializer found" error thrown when trying to use mode = global.